### PR TITLE
fix for fall through bug with ignore collision

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -45,6 +45,9 @@ public class PlayerController : MonoBehaviour
         rb2d = GetComponent<Rigidbody2D>();
         playerAudioSource = GetComponent<AudioSource>();
         animation = GetComponent<Animator>();
+
+        //To prevent the bug that makes player fall through from happening
+        Physics2D.IgnoreLayerCollision(gameObject.layer, LayerMask.NameToLayer(GROUND_LAYER_NAME), false);
     }
 
     void Start()


### PR DESCRIPTION
when player velocity is > 0 as game ends, said player will keep falling
through ground repeatedly when restart game button is clicked