### PR TITLE
Power up pickup and wrong color fixes

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -58,6 +58,14 @@ public class PlayerController : MonoBehaviour
 
     void Update()
     {
+        //Check if the player's stats are normal, if they are but their color isn't white, change it back to white
+            //This is a workaround for when a player is affected by both Slow and another PowerUp, but when both are over they're
+            //still not the default color
+        if (moveSpeed == 300f && MaxJumps == 1)
+        {
+            GetComponent<Renderer>().material.color = Color.white;
+            has_power = false;
+        }
         //Linecast to check if player is on ground
         //3 linecasts for more accurate ground checks
         //grounded1 = Physics2D.Linecast(transform.position, groundCheck1.transform.position, 1 << LayerMask.NameToLayer("Ground"));
@@ -67,6 +75,7 @@ public class PlayerController : MonoBehaviour
         //If Player pressed W and is grounded, jump
         if (Input.GetButtonDown(PLAYER_INPUT_JUMP_STRING) && (CurrentJumps >= 1))
         {
+            
             jump = true;
             playerAudioSource.PlayOneShot(jumpAudioClip);
         }

--- a/Assets/Scripts/PowerUp.cs
+++ b/Assets/Scripts/PowerUp.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class PowerUp : MonoBehaviour {
-    bool pickedUp = false;
+    public bool pickedUp = false;
     GameObject Player;
     //Abstract class for powerups
 

--- a/Assets/Scripts/PowerUp_DblJump.cs
+++ b/Assets/Scripts/PowerUp_DblJump.cs
@@ -28,9 +28,7 @@ public class PowerUp_DblJump : PowerUp {
     public override void ActivatePowerUp(GameObject player)
     {
         //Makes two jumps available to the player
-        //Also currently changes the player's material to indicate that they're powered up
-
-        //Changes Material back to the previous one
+        
         if(poweredUp == false)
         { 
             powerupAudioSource.PlayOneShot(collectAudioClip);
@@ -55,6 +53,7 @@ public class PowerUp_DblJump : PowerUp {
     {
         //Reverts all changes the power-up made to the player
         PController.GetComponent<Renderer>().material.color = oldColor;
+        
         PController.MaxJumps = 1;
         poweredUp = false;
     }

--- a/Assets/Scripts/PowerUp_Speed.cs
+++ b/Assets/Scripts/PowerUp_Speed.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class PowerUp_Speed : PowerUp {
     //Floats holding default values for how much the Speed Power Up boosts the player
-    PlayerController PController;
+    public PlayerController PController;
 
     public float SpeedCapIncrease = 1.5f;
     public float JumpForceIncrease = 1f;
@@ -35,6 +35,7 @@ public class PowerUp_Speed : PowerUp {
         if (poweredUp == false)
         {
             powerupAudioSource.PlayOneShot(collectAudioClip);
+            PController = player.GetComponent<PlayerController>();
 
             if (SpeedCapIncrease < 0)
             {
@@ -43,8 +44,8 @@ public class PowerUp_Speed : PowerUp {
                 else
                     PController = GameObject.FindGameObjectWithTag("Player 1").GetComponent<PlayerController>();
             }
-            else
-                PController = player.GetComponent<PlayerController>(); 
+            
+                
             
             oldColor = PController.gameObject.GetComponent<Renderer>().material.color;
             
@@ -64,7 +65,7 @@ public class PowerUp_Speed : PowerUp {
             poweredUp = true;
 
             PSystem.Play();
-
+            
             gameObject.GetComponent<Renderer>().enabled = false;
         }
     }


### PR DESCRIPTION
-PlayerController will now check if the players' stats are normal and
return them to the default state if they are (including color and being
able to pickup a new power up)